### PR TITLE
Open VOD as new tab

### DIFF
--- a/src/lib/components/match/MatchInfoRow.svelte
+++ b/src/lib/components/match/MatchInfoRow.svelte
@@ -41,7 +41,7 @@
 		</div>
 
 		{#if match.vodUrl}
-			<a class="hover:underline" href={match.vodUrl} target="_blank">
+			<a class="hover:underline" href={match.vodUrl} target="_blank" rel="noopener noreferrer">
 				<Icon icon="ph:arrow-square-out" />
 				VOD
 			</a>


### PR DESCRIPTION
Multiple users complained about being redirected to the vod, instead of it being opened in a new tab. This new functionality will improve ux and user retention, providing a sizeable increase in traffic and exposure.